### PR TITLE
PERF-4439 Print bucketCatalog metrics from serverStatus after loading

### DIFF
--- a/cmd/tsbs_load_mongo/creator.go
+++ b/cmd/tsbs_load_mongo/creator.go
@@ -142,5 +142,17 @@ func (d *dbCreator) CreateDB(dbName string) error {
 }
 
 func (d *dbCreator) Close() {
+	serverStatusCmd := make(bson.D, 0, 4)
+	serverStatusCmd = append(serverStatusCmd, bson.E{"serverStatus", 1})
+
+	var result struct {
+		BucketCatalog bson.Raw
+	}
+
+	err := d.client.Database("admin").RunCommand(context.Background(), serverStatusCmd).Decode(&result)
+	if err == nil {
+		fmt.Println(result)
+	}
+
 	d.client.Disconnect(context.Background())
 }


### PR DESCRIPTION
time,per. metric/s,metric total,overall metric/s,per. row/s,row total,overall row/s
...

{{"numBuckets": {"$numberInt":"34"},"numOpenBuckets": {"$numberInt":"34"},"numIdleBuckets": {"$numberInt":"34"},"numArchivedBuckets": {"$numberInt":"0"},"memoryUsage": {"$numberInt":"301566"},"numBucketInserts": {"$numberInt":"34"},"numBucketUpdates": {"$numberInt":"0"},"numBucketsOpenedDueToMetadata": {"$numberInt":"34"},"numBucketsClosedDueToCount": {"$numberInt":"0"},"numBucketsClosedDueToSchemaChange": {"$numberInt":"0"},"numBucketsClosedDueToSize": {"$numberInt":"0"},"numBucketsClosedDueToTimeForward": {"$numberInt":"0"},"numBucketsClosedDueToTimeBackward": {"$numberInt":"0"},"numBucketsClosedDueToMemoryThreshold": {"$numberInt":"0"},"numCommits": {"$numberInt":"34"},"numMeasurementsGroupCommitted": {"$numberInt":"0"},"numWaits": {"$numberInt":"0"},"numMeasurementsCommitted": {"$numberInt":"9792"},"avgNumMeasurementsPerCommit": {"$numberInt":"288"},"numBucketsClosedDueToReopening": {"$numberInt":"0"},"numBucketsArchivedDueToMemoryThreshold": {"$numberInt":"0"},"numBucketsArchivedDueToTimeBackward": {"$numberInt":"0"},"numBucketsReopened": {"$numberInt":"0"},"numBucketsKeptOpenDueToLargeMeasurements": {"$numberInt":"0"},"numBucketsClosedDueToCachePressure": {"$numberInt":"0"},"numBucketsFrozen": {"$numberInt":"0"},"numCompressedBucketsConvertedToUnsorted": {"$numberInt":"0"},"numBucketsFetched": {"$numberInt":"0"},"numBucketsQueried": {"$numberInt":"0"},"numBucketFetchesFailed": {"$numberInt":"0"},"numBucketQueriesFailed": {"$numberInt":"34"},"numBucketReopeningsFailed": {"$numberInt":"0"},"numDuplicateBucketsReopened": {"$numberInt":"0"},"numBytesUncompressed": {"$numberInt":"0"},"numBytesCompressed": {"$numberInt":"0"},"numSubObjCompressionRestart": {"$numberInt":"0"},"numCompressedBuckets": {"$numberInt":"0"},"numUncompressedBuckets": {"$numberInt":"0"},"numFailedDecompressBuckets": {"$numberInt":"0"},"stateManagement": {"bucketsManaged": {"$numberInt":"34"},"currentEra": {"$numberInt":"34"},"erasWithRemainingBuckets": {"$numberInt":"34"},"trackedClearOperations": {"$numberInt":"34"}}}}

Summary:
loaded 2880 metrics in 0.089sec with 16 workers (mean rate 32498.76 metrics/sec)