### PR TITLE
PERF-6207: Making data generation have batching by host points

### DIFF
--- a/internal/inputs/generator_data.go
+++ b/internal/inputs/generator_data.go
@@ -109,6 +109,11 @@ func (g *DataGenerator) runSimulator(sim common.Simulator, serializer serialize.
 	for !sim.Finished() {
 		write := sim.Next(point)
 		if !write {
+			// When we batch host points, we need to check if we are finished
+			// each time we call sim.Next() or we can go out-of-bounds
+			if dgc.BatchHostPoints && sim.Finished() {
+				break
+			}
 			point.Reset()
 			continue
 		}

--- a/pkg/data/usecases/common/generator.go
+++ b/pkg/data/usecases/common/generator.go
@@ -37,6 +37,7 @@ type DataGeneratorConfig struct {
 	Limit                 uint64        `yaml:"max-data-points" mapstructure:"max-data-points"`
 	InitialScale          uint64        `yaml:"initial-scale" mapstructure:"initial-scale" `
 	LogInterval           time.Duration `yaml:"log-interval" mapstructure:"log-interval"`
+	BatchHostPoints	  	  bool 			`yaml:"batch-host-points" mapstructure:"batch-host-points"`
 	InterleavedGroupID    uint          `yaml:"interleaved-generation-group-id" mapstructure:"interleaved-generation-group-id"`
 	InterleavedNumGroups  uint          `yaml:"interleaved-generation-groups" mapstructure:"interleaved-generation-groups"`
 	MaxMetricCountPerHost uint64        `yaml:"max-metric-count" mapstructure:"max-metric-count"`
@@ -77,6 +78,7 @@ func (c *DataGeneratorConfig) AddToFlagSet(fs *pflag.FlagSet) {
 	fs.Uint("interleaved-generation-groups", 1,
 		"The number of round-robin serialization groups. Use this to scale up data generation to multiple processes.")
 	fs.Uint64("max-metric-count", 100, "Max number of metric fields to generate per host. Used only in devops-generic use-case")
+	fs.Bool("batch-host-points", false, "Generates the data by batching the data from each host")
 }
 
 const defaultTimeStart = "2016-01-01T00:00:00Z"

--- a/pkg/data/usecases/devops/cpu_only_generate_data.go
+++ b/pkg/data/usecases/devops/cpu_only_generate_data.go
@@ -49,12 +49,14 @@ func (d *CPUOnlySimulator) Next(p *data.Point) bool {
 	} else {
 		if d.hostIndex == uint64(len(d.hosts)) {
 			d.hostIndex = 0
-
+	
 			for i := 0; i < len(d.hosts); i++ {
 				d.hosts[i].TickAll(d.interval)
 			}
+	
 			d.adjustNumHostsForEpoch()
 		}
+	
 	}
 	return d.populatePoint(p, 0)
 }

--- a/pkg/data/usecases/devops/cpu_only_generate_data.go
+++ b/pkg/data/usecases/devops/cpu_only_generate_data.go
@@ -1,8 +1,6 @@
 package devops
 
 import (
-	"fmt"
-
 	"github.com/timescale/tsbs/pkg/data"
 	"github.com/timescale/tsbs/pkg/data/usecases/common"
 	"time"
@@ -29,7 +27,6 @@ func (d *CPUOnlySimulator) Headers() *common.GeneratedDataHeaders {
 
 // Next advances a Point to the next state in the generator.
 func (d *CPUOnlySimulator) Next(p *data.Point) bool {
-	fmt.Println("batchHostPoints: ", d.batchHostPoints)
 	// Switch to the next metric if needed
 	if (d.batchHostPoints) {
 		// Max points is across all the hosts.

--- a/pkg/data/usecases/usecases.go
+++ b/pkg/data/usecases/usecases.go
@@ -52,6 +52,7 @@ func GetSimulatorConfig(dgc *common.DataGeneratorConfig) (common.SimulatorConfig
 			InitHostCount:   dgc.InitialScale,
 			HostCount:       dgc.Scale,
 			HostConstructor: devops.NewHostCPUOnly,
+			BatchHostPoints: dgc.BatchHostPoints,
 		}
 	case common.UseCaseCPUSingle:
 		ret = &devops.CPUOnlySimulatorConfig{
@@ -61,6 +62,7 @@ func GetSimulatorConfig(dgc *common.DataGeneratorConfig) (common.SimulatorConfig
 			InitHostCount:   dgc.InitialScale,
 			HostCount:       dgc.Scale,
 			HostConstructor: devops.NewHostCPUSingle,
+			BatchHostPoints: dgc.BatchHostPoints,
 		}
 	case common.UseCaseDevopsGeneric:
 		if dgc.InitialScale == dgc.Scale {


### PR DESCRIPTION
Enables only the cpu-only data generation to have the option to batch outputting the generated data points by the host name. Prior, you would only have:
```
host_1 + relevant data...
host_2 + relevant data...
...
host_n + relevant data...
```
Now we batch by:
```
host_1 + relevant data...
host_1 + relevant data...
...
host_2 + relevant data...
host_2 + relevant data...
...
```
Is **not compatible** if we have the case that we change the number of hosts; however, for cpu-only data generation, we have the case that the number of hosts do not change, as shown by us setting 
