### PR TITLE
PERF-6233: Enables bulk load contention workload through not unconditionally setting HashWorkers true

### DIFF
--- a/cmd/tsbs_load_mongo/main.go
+++ b/cmd/tsbs_load_mongo/main.go
@@ -85,9 +85,14 @@ func init() {
 	metaFieldIndex = viper.GetString("meta-field-index")
 	granularity = viper.GetString("granularity")
 	
-	config.HashWorkers = true
+	if documentPer  {
+		config.HashWorkers = false
+	} else {
+		config.HashWorker = true
+	}
 
 	if batchMetaFields {
+		config.HashWorkers = true
 		config.BatchMetaFields = true
 		config.MetaFieldIndex = metaFieldIndex
 	}

--- a/cmd/tsbs_load_mongo/main.go
+++ b/cmd/tsbs_load_mongo/main.go
@@ -88,7 +88,7 @@ func init() {
 	if documentPer  {
 		config.HashWorkers = false
 	} else {
-		config.HashWorker = true
+		config.HashWorkers = true
 	}
 
 	if batchMetaFields {


### PR DESCRIPTION
Setting `HashWorkers` to true acts by making a 2D array, `batches`, where we have the x-axis as the number of workers we have, with the length of 1.
Setting `HashWorkers` to false is having batches have the x axis 1, and the queue as the number of workers.
Remember, we don't lose inserting any other data because for each of the x-axis value, we have another queue (`unsentBatches`) that can store batches that are also filled and are waiting to be inserted into a the channels queue.

We run into the following issue if we turn on `HashWorkers` as true when we aren't batching meta fields:
Let's say we have the case where we have one meta index (bulk load contended case).
If we set `HashWorkers` to true, then we will always place a task on the queue that is the index of the worker (lets call this `workerNum`), which can lead to sequential processing because the same thread will always grab `batches[workerNum]` queue. On the other hand, if we set `HashWorkers` to `false`, we can actually simulate the contention, because all the workers will grab from `batches[0]` (logic is [linked here](https://github.com/mongodb-forks/tsbs/blob/main/load/loader.go#L200) for when we set the workers to "grab" from the `batches[workerNum % numChannels]`)

To fix this, we simply need to make it so that when we have `documentPer` set, **we only set HashWorkers to true when --batch-meta-fields is true.**

This **does not** impact the workload associated with PERF-6233, but will impact all other workloads that set --batch-meta-fields to false. ~~I also suspect that this is leading to significant performance regressions when loading tsbs data, which is why we are seeing timeouts for medium and high cardinality loading runs (> 50 hours) when the previous high cardinality workload that has a greater cardinality than the new high cardinality workload has a  (2_300_000 > 2_000_000 scale) but takes less time (< 48 days to load).~~
For tsbs_load, we actually experienced performance improvements when we enabled HashWorkers unconditionally. The question is if we want to **simulate contention**.

We do still need to enable this when we batch meta fields or we aren't actually going to be properly uploading batches with the same meta values.