### PR TITLE
PERF-7767 Add a JSONL encoder in order to facilitate integration of TSBS workloads with Locust

### DIFF
--- a/internal/inputs/generator_queries.go
+++ b/internal/inputs/generator_queries.go
@@ -13,6 +13,7 @@ import (
 	queryUtils "github.com/timescale/tsbs/cmd/tsbs_generate_queries/utils"
 	internalUtils "github.com/timescale/tsbs/internal/utils"
 	"github.com/timescale/tsbs/pkg/data/usecases/common"
+	"github.com/timescale/tsbs/pkg/query"
 	"github.com/timescale/tsbs/pkg/query/config"
 	"github.com/timescale/tsbs/pkg/query/factories"
 )
@@ -214,7 +215,7 @@ func (g *QueryGenerator) getUseCaseGenerator(c *config.QueryGeneratorConfig) (qu
 
 // queryEncoder abstracts the encoding of a query to either gob or JSONL format.
 type queryEncoder interface {
-	Encode(q queryUtils.Query) error
+	Encode(q query.Query) error
 }
 
 // gobQueryEncoder encodes queries using Go's gob format (the original default).
@@ -222,7 +223,7 @@ type gobQueryEncoder struct {
 	enc *gob.Encoder
 }
 
-func (e *gobQueryEncoder) Encode(q queryUtils.Query) error {
+func (e *gobQueryEncoder) Encode(q query.Query) error {
 	return e.enc.Encode(q)
 }
 
@@ -232,7 +233,7 @@ type jsonlQueryEncoder struct {
 	w *bufio.Writer
 }
 
-func (e *jsonlQueryEncoder) Encode(q queryUtils.Query) error {
+func (e *jsonlQueryEncoder) Encode(q query.Query) error {
 	type extJSONer interface {
 		ToExtJSON() ([]byte, error)
 	}

--- a/scripts/generate_queries.sh
+++ b/scripts/generate_queries.sh
@@ -57,6 +57,16 @@ TS_END=${TS_END:-"2016-01-04T00:00:01Z"}
 # What set of data to generate: devops (multiple data), cpu-only (cpu-usage data)
 USE_CASE=${USE_CASE:-"cpu-only"}
 
+# Output serialization format: "gob" (default, binary) or "jsonl" (JSON Lines)
+OUTPUT_FORMAT=${OUTPUT_FORMAT:-"gob"}
+
+# Determine file extension based on output format
+if [ "${OUTPUT_FORMAT}" == "jsonl" ]; then
+    FILE_EXT="jsonl.gz"
+else
+    FILE_EXT="dat.gz"
+fi
+
 # Ensure DATA DIR available
 mkdir -p ${BULK_DATA_DIR}
 chmod a+rwx ${BULK_DATA_DIR}
@@ -67,7 +77,7 @@ set -eo pipefail
 # Loop over all requested queries types and generate data
 for QUERY_TYPE in ${QUERY_TYPES}; do
     for FORMAT in ${FORMATS}; do
-        DATA_FILE_NAME="queries_${FORMAT}_${QUERY_TYPE}_${EXE_FILE_VERSION}_${QUERIES}_${SCALE}_${SEED}_${TS_START}_${TS_END}_${USE_CASE}.dat.gz"
+        DATA_FILE_NAME="queries_${FORMAT}_${QUERY_TYPE}_${EXE_FILE_VERSION}_${QUERIES}_${SCALE}_${SEED}_${TS_START}_${TS_END}_${USE_CASE}.${FILE_EXT}"
         if [ -f "${DATA_FILE_NAME}" ]; then
             echo "WARNING: file ${DATA_FILE_NAME} already exists, skip generating new data"
         else
@@ -87,6 +97,7 @@ for QUERY_TYPE in ${QUERY_TYPES}; do
                 --timestamp-start ${TS_START} \
                 --timestamp-end ${TS_END} \
                 --use-case ${USE_CASE} \
+                --output-format ${OUTPUT_FORMAT} \
                 --timescale-use-json=${USE_JSON} \
                 --timescale-use-tags=${USE_TAGS} \
                 --timescale-use-time-bucket=${USE_TIME_BUCKET} \


### PR DESCRIPTION
At a high level, this change adds the `--output-format` flag to the Go query generator, which can take either `gob` (default) or `jsonl` as options. A JSONL encoder is also added to fit the second option.

The JSONL encoder will enable the DSI repo to use a JSONL decoder in order to run each query in Locust, instead of relying on `run_queries_mongo.sh`. This will ultimately improve observability of the workloads, as logging and profiling becomes seamless, and makes tuning the workload much easier.

This change is backwards-compatible as the new flag defaults to `gob`, which is the format used by all workloads currently.

The new flag and encoder were tested manually by generating and reading queries from the command line, as well as by the new unit test added.